### PR TITLE
Enable PSI BARs to get interrupts from second proc

### DIFF
--- a/barreleye.xml
+++ b/barreleye.xml
@@ -8486,7 +8486,7 @@
 	</attribute>
 	<attribute>
 		<id>PSI_BRIDGE_BASE_ADDR</id>
-		<default>0,0x0000000000000000</default>
+		<default>1,0x0003FFFE80000000,0x2000000,0x400000,0x0</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>


### PR DESCRIPTION
Modified calculation for PSI BAR to get a non-zero value.  This
is needed to get attention interrupts from the second processor.

Suggested-by: Alvin Wang wangat@tw.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/barreleye-xml/7)

<!-- Reviewable:end -->
